### PR TITLE
WYSIWYG edit and fields up/down issues

### DIFF
--- a/js/designer_content_dashboard_ui.js
+++ b/js/designer_content_dashboard_ui.js
@@ -3,8 +3,8 @@ $(document).ready(function() {
 	
 	$('body').on('click', 'a.add-field-type', add_new_field); 
 	
-	$('.designer-content-field-move-up').on('click', 'a', move_field_up);
-	$('.designer-content-field-move-down').on('click', 'a', move_field_down);
+	$('body').on('click', '.designer-content-field-move-up a', move_field_up);
+	$('body').on('click', '.designer-content-field-move-down a', move_field_down);
 
 	$('body').on('click', 'a.designer-content-field-delete', toggle_delete_confirmation);
 	$('body').on('click', 'a.designer-content-field-delete-no', toggle_delete_confirmation);

--- a/libraries/block_generator.php
+++ b/libraries/block_generator.php
@@ -633,7 +633,7 @@ class BlockGenerator {
 			if ($field['type'] == 'wysiwyg') {
 				$code .= "<div class=\"ccm-block-field-group\">\n";
 				$code .= "\t<h2>{$field['label']}</h2>\n";
-				$code .= "\t<?php print Core::make('editor')->outputStandardEditor('field_{$field['num']}_wysiwyg_content'); ?>\n";
+				$code .= "\t<?php print Core::make('editor')->outputStandardEditor('field_{$field['num']}_wysiwyg_content', \$field_{$field['num']}_wysiwyg_content); ?>\n";
 				$code .= "</div>\n\n";
 				$include_editor_config = false;
 			}

--- a/src/BlockGenerator/BlockGenerator.php
+++ b/src/BlockGenerator/BlockGenerator.php
@@ -633,7 +633,7 @@ class BlockGenerator {
 			if ($field['type'] == 'wysiwyg') {
 				$code .= "<div class=\"ccm-block-field-group\">\n";
 				$code .= "\t<h2>{$field['label']}</h2>\n";
-				$code .= "\t<?php print Core::make('editor')->outputStandardEditor('field_{$field['num']}_wysiwyg_content'); ?>\n";
+				$code .= "\t<?php print Core::make('editor')->outputStandardEditor('field_{$field['num']}_wysiwyg_content', \$field_{$field['num']}_wysiwyg_content); ?>\n";
 				$code .= "</div>\n\n";
 				$include_editor_config = false;
 			}


### PR DESCRIPTION
Added a second parameter in Core::make('editor')->outputStandardEditor()
to pull in the saved content